### PR TITLE
ASM-8472 Work around dracut module bug in CentOS 7.2

### DIFF
--- a/microkernel.ks
+++ b/microkernel.ks
@@ -50,6 +50,12 @@ dmidecode
 virt-what
 lldpad
 
+# Fix dmsquash-live problem in CentOS 7.2
+# https://bugzilla.redhat.com/show_bug.cgi?id=1285810
+tar
+gzip
+coreutils
+
 # Only needed because livecd-tools runs /usr/bin/firewall-offline-cmd
 # unconditionally; patch submitted upstream. Remove once released version
 # with it is available
@@ -96,7 +102,6 @@ net-tools
 -prelink
 -setserial
 -ed
--tar
 
 # Remove the authconfig pieces
 -authconfig


### PR DESCRIPTION
When trying to build the razor microkernel against CentOS 7.2 the
error message "Dracut module 'dmsquash-live' depends on 'img-lib' in
kernel scriptlet" was thrown when by the kernel post-install
script. This blocked creation of the initrd.img file and led to
a non-functional image being creatd.

The issue is tracked by [RH Bugzilla #1285810][0] and should be fixed
in RH / CentOS 7.3. The workaround is to include tar, gzip, dd and
bash as packages in the microkernel.ks file. That fixes the problem
which was a dependency issue -- the img_lib module didn't declare its
dependencies on those utilities.

[0]: https://bugzilla.redhat.com/show_bug.cgi?id=1285810